### PR TITLE
Fix for local environment

### DIFF
--- a/crystal-d_codetest/public/scripts/client.js
+++ b/crystal-d_codetest/public/scripts/client.js
@@ -22,7 +22,7 @@ function readyNow () {
 function getApiData () {
     $.ajax({
         method: 'GET',
-        url: 'http://localhost:8888/php-scripts/get-api-data.php'
+        url: 'scripts/get-api-data.php'
     }).then( (response) => {
         console.log(response)
         let myObject = JSON.parse(response)


### PR DESCRIPTION
No need to call local host from current environment. Was getting cross-origin fault. PHP script is now called relatively.